### PR TITLE
Remove extraneous push in Release task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -35,13 +35,12 @@ desc "Release version #{Workarea::AuthorizeCim::VERSION} of the gem"
 task :release do
   host = "https://#{ENV['BUNDLE_GEMS__WEBLINC__COM']}@gems.weblinc.com"
 
-  #Rake::Task["workarea:changelog"].execute
-  #system "git add CHANGELOG.md"
-  #system 'git commit -m "Update CHANGELOG"'
-  #system "git push origin HEAD"
+  Rake::Task["workarea:changelog"].execute
+  system "git add CHANGELOG.md"
+  system 'git commit -m "Update CHANGELOG"'
 
   system "git tag -a v#{Workarea::AuthorizeCim::VERSION} -m 'Tagging #{Workarea::AuthorizeCim::VERSION}'"
-  system 'git push --tags'
+  system 'git push origin HEAD --follow-tags'
 
   system 'gem build workarea-authorize_cim.gemspec'
   system "gem push workarea-authorize_cim-#{Workarea::AuthorizeCim::VERSION}.gem"


### PR DESCRIPTION
We're running out of minutes in our GitHub actions due to duplicate pushes
during a release. This consolidates the two pushes into one.

No changelog

WORKAREA-148