### PR TITLE
Added fields to include IP in transactions

### DIFF
--- a/app/controllers/workarea/storefront/checkout/place_order_controller.decorator
+++ b/app/controllers/workarea/storefront/checkout/place_order_controller.decorator
@@ -1,0 +1,8 @@
+module Workarea
+  decorate Storefront::Checkout::PlaceOrderController, with: :cim do
+    def place_order
+      params.merge!(ip: request.remote_ip)
+      super
+    end
+  end
+end

--- a/app/controllers/workarea/storefront/checkout/place_order_controller.decorator
+++ b/app/controllers/workarea/storefront/checkout/place_order_controller.decorator
@@ -1,8 +1,0 @@
-module Workarea
-  decorate Storefront::Checkout::PlaceOrderController, with: :cim do
-    def place_order
-      params.merge!(ip: request.remote_ip)
-      super
-    end
-  end
-end

--- a/app/models/workarea/checkout/steps/payment.decorator
+++ b/app/models/workarea/checkout/steps/payment.decorator
@@ -1,0 +1,15 @@
+module Workarea
+  decorate Checkout::Steps::Payment, with: :cim do
+
+    private
+
+    def set_credit_card(params)
+      super
+
+      return unless payment.credit_card.present?
+      payment.credit_card.tap do |card|
+        card.update_attributes(ip_address: params[:ip])
+      end
+    end
+  end
+end

--- a/app/models/workarea/checkout/steps/payment.decorator
+++ b/app/models/workarea/checkout/steps/payment.decorator
@@ -8,7 +8,7 @@ module Workarea
 
       return unless payment.credit_card.present?
       payment.credit_card.tap do |card|
-        card.update_attributes(ip_address: params[:ip])
+        card.update_attributes(ip_address: order.ip_address)
       end
     end
   end

--- a/app/models/workarea/payment/authorize/credit_card.decorator
+++ b/app/models/workarea/payment/authorize/credit_card.decorator
@@ -29,6 +29,9 @@ module Workarea
           order: {
             invoice_number: tender.payment.id.first(20) # auth net has max length 20 for this field
           }
+        },
+        extra_options: {
+          x_customer_ip: tender.ip_address
         }
       }
     end
@@ -42,6 +45,10 @@ module Workarea
           trans_id: transaction.response.authorization
         }
       }
+    end
+
+    def customer_ip_address
+      tender.ip_address
     end
 
     def customer_profile_id

--- a/app/models/workarea/payment/authorize/credit_card.decorator
+++ b/app/models/workarea/payment/authorize/credit_card.decorator
@@ -31,7 +31,7 @@ module Workarea
           }
         },
         extra_options: {
-          x_customer_ip: tender.ip_address
+          x_customer_ip: customer_ip_address
         }
       }
     end

--- a/app/models/workarea/payment/purchase/credit_card.decorator
+++ b/app/models/workarea/payment/purchase/credit_card.decorator
@@ -30,7 +30,7 @@ module Workarea
             invoice_number: tender.payment.id.first(20) # auth net has max length 20 for this field
           },
           extra_options: {
-            x_customer_ip: tender.ip_address
+            x_customer_ip: customer_ip_address
           }
         }
       }

--- a/app/models/workarea/payment/purchase/credit_card.decorator
+++ b/app/models/workarea/payment/purchase/credit_card.decorator
@@ -28,6 +28,9 @@ module Workarea
           amount: auth_amount,
           order: {
             invoice_number: tender.payment.id.first(20) # auth net has max length 20 for this field
+          },
+          extra_options: {
+            x_customer_ip: tender.ip_address
           }
         }
       }
@@ -42,6 +45,10 @@ module Workarea
           trans_id: transaction.response.authorization
         }
       }
+    end
+
+    def customer_ip_address
+      tender.ip_address
     end
 
     def customer_profile_id


### PR DESCRIPTION
IP address is stored on tender when the order is being placed.
It is then passed along as an argument when submitting the transaction to Authorize.net